### PR TITLE
Update Link header name

### DIFF
--- a/function/push-gitlab-pending-jobs-metric.py
+++ b/function/push-gitlab-pending-jobs-metric.py
@@ -84,9 +84,9 @@ def get_all_project_ids(token):
             if last_activity > hours_ago:
                 LOGGER.debug('Found project with last activity {}'.format(last_activity_str))
                 project_ids.extend([pid])
-        if 'Links' not in res.headers:
+        if 'Link' not in res.headers:
             break
-        link = res.headers['Links'].split('<')[1].split('>')[0]
+        link = res.headers['Link'].split('<')[1].split('>')[0]
     LOGGER.info("Found project ids: {}".format(project_ids))
     LOGGER.info("Number of projects processes: {}".format(total_numb_of_projects))
     return project_ids


### PR DESCRIPTION
The Links header was removed in GitLab 14.0 to be aligned with the W3C Link specification. The Link header was added in GitLab 13.1 and should be used instead. 

https://gitlab.com/gitlab-org/gitlab/-/merge_requests/33714